### PR TITLE
Support attaching to an existing session

### DIFF
--- a/gssapi-console.py
+++ b/gssapi-console.py
@@ -2,6 +2,8 @@
 
 # interactive console with easy access to krb5 test harness stuff
 
+from __future__ import print_function
+
 import argparse
 import os
 import sys
@@ -25,6 +27,11 @@ parser.add_argument('--realm-args', default=None,
 parser.add_argument('--mech', default='krb5',
                     help='Which environment to setup up '
                          '(supports krb5 [default])')
+parser.add_argument('-a, --attach', metavar='IDENTIFIER', nargs='?',
+                    default=None, dest='attach',
+                    help='Attach to an existing gssapi-console environment, '
+                         'indicated by IDENTIFIER.')
+
 
 PARSED_ARGS = parser.parse_args()
 
@@ -48,7 +55,7 @@ SAVED_ENV = None
 try:
     # import the env
     SAVED_ENV = copy.deepcopy(os.environ)
-    console = GSSAPIConsole(mech_cls, realm_args=realm_args)
+    console = GSSAPIConsole(mech_cls, realm_args=realm_args, attach=PARSED_ARGS.attach)
     for k, v in console.realm.env.items():
         os.environ[k] = v
 
@@ -57,6 +64,8 @@ try:
     if PARSED_ARGS.file is not None:
         if not PARSED_ARGS.force_interactive:
             INTER = False
+
+        print('Session: {0}'.format(console.session))
 
         with open(PARSED_ARGS.file) as src:
             console.runsource(src.read(), src.name, 'exec')

--- a/gssapi_console/drivers.py
+++ b/gssapi_console/drivers.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 
@@ -9,6 +10,12 @@ class GSSAPIConsoleDriver(object):
         return None
 
     def destroy_realm(self, realm):
+        pass
+
+    def attach_to_realm(self, identifier, realm_args={}):
+        pass
+
+    def identifier(self, realm):
         return None
 
 
@@ -25,3 +32,9 @@ class Krb5Console(GSSAPIConsoleDriver):
 
     def destroy_realm(self, realm):
         realm.stop()
+
+    def attach_to_realm(self, identifier, realm_args={}):
+        return self._k5test.K5Realm(existing=identifier, **realm_args)
+
+    def identifier(self, realm):
+        return realm.tmpdir

--- a/gssapi_console/drivers.py
+++ b/gssapi_console/drivers.py
@@ -17,8 +17,8 @@ class Krb5Console(GSSAPIConsoleDriver):
     PROVIDER_NAME = 'MIT Kerberos 5'
 
     def __init__(self):
-        __import__('gssapi.tests.k5test')
-        self._k5test = sys.modules['gssapi.tests.k5test']
+        __import__('k5test')
+        self._k5test = sys.modules['k5test']
 
     def create_realm(self, realm_args):
         return self._k5test.K5Realm(**realm_args)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     },
     install_requires=[
         'gssapi',
+        'k5test',
         'six'
     ]
 )


### PR DESCRIPTION
This commit adds support for attaching to an existing session.
To do so, use the '-a' or '--attach' flag with the session identifier
printed out in the gssapi-console banner (for example, the identifier
for the krb5 mech is the tmp directory path).

**NB**: Currently, this bundles a modified version of k5test.  Eventually, I would like to split it out from both this and python-gssapi entirely.
